### PR TITLE
Statics

### DIFF
--- a/middleware/controllers.js
+++ b/middleware/controllers.js
@@ -16,10 +16,6 @@ module.exports = function(app, fundation) {
   debug("Setting up Controllers");
 
   //
-  // Remove the x-powered-by
-  //
-
-  //
   // Enable case sensitivity
   // "/Foo" and "/foo" will be treated as seperate routes
   //

--- a/middleware/controllers.js
+++ b/middleware/controllers.js
@@ -18,10 +18,6 @@ module.exports = function(app, fundation) {
   //
   // Remove the x-powered-by
   //
-  app.use(function (req, res, next) {
-    res.header("X-powered-by", "Fundation, the fun way to go!");
-    next();
-  });
 
   //
   // Enable case sensitivity

--- a/middleware/statics.js
+++ b/middleware/statics.js
@@ -13,7 +13,8 @@ var fs             = require('fs');
 module.exports = function(app) {
 
   debug("Setting up CSS and JS");
-
+  var config = app.get('config').cache;
+  var cacheTime =  config.staticTime || 300; //time to cache in seconds
   //
   // Compress all requests
   // Adds the following to the "Response Headers"
@@ -66,7 +67,7 @@ module.exports = function(app) {
   }
 
   app.use('/ui/js/common.js', function(req, res, next){
-    res.setHeader('Cache-Control', 'public, max-age=300');
+    res.setHeader('Cache-Control', 'public, max-age='+cacheTime);
     res.setHeader('Content-Type', 'text/javascript');
     b.bundle(function(error, buffer){
       // Send the browerified results first
@@ -118,7 +119,7 @@ module.exports = function(app) {
   // Make it trivial to serve static files
   // http://expressjs.com/guide/using-middleware.html#express.static
   //
-  app.use(express.static(path.join('./public'), { maxAge: '5m' }));
+  app.use(express.static(path.join('./public'), { maxAge: cacheTime*1000 }));
 
   //
   // Load the favicon


### PR DESCRIPTION
Configurable cache times, remove X-Powered-By header (disable completely in apps by setting app.disable('X-Powered-By'))
