### PR TITLE
exclude request

### DIFF
--- a/middleware/statics.js
+++ b/middleware/statics.js
@@ -69,6 +69,7 @@ module.exports = function(app) {
   app.use('/ui/js/common.js', function(req, res, next){
     res.setHeader('Cache-Control', 'public, max-age='+cacheTime);
     res.setHeader('Content-Type', 'text/javascript');
+    b.exclude('request');
     b.bundle(function(error, buffer){
       // Send the browerified results first
       if (buffer) {


### PR DESCRIPTION
exclude the request package so it doesnt get included in browser side common.js bundle if an npm module is used that conditionally switches between request and a browser side alternative
